### PR TITLE
Support relative path for mypy.executable with ${workspaceFolder} (#20)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,9 @@ export function activate(context: ExtensionContext) {
 			'~\\.mypyls\\Scripts\\mypyls.exe' :
 			'~/.mypyls/bin/mypyls';
 	}
-	const executable = untildify(executableSetting);
+	const executable = executableSetting.startsWith('${workspaceFolder}')
+		? executableSetting.replace('${workspaceFolder}', workspace.rootPath)
+		: untildify(executableSetting);
 	if (!fs.existsSync(executable)) {
 		window.showWarningMessage(
 			'mypyls not found. Please install mypyls and reload. See extension installation instructions. ' +


### PR DESCRIPTION
I added `${workspaceFolder}` replacement for `mypy.executable`.

Related to #20.