### PR TITLE
Write logs from dmypy

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,11 +238,20 @@ async function forEachFolder<T>(folders: readonly T[] | undefined, func: (folder
 	}
 }
 
+function mkStoragePath(folder: vscode.Uri, namer: (folderHash: string) => string): string | undefined {
+	if (_context?.storageUri !== undefined) {
+		fs.mkdirSync(_context.storageUri.fsPath, {recursive: true});
+		const folderHash = crypto.createHash('sha1').update(folder.toString()).digest('hex');
+		const fileName = namer(folderHash);
+		return path.join(_context.storageUri.fsPath, fileName);
+	}
+	return undefined;
+}
 
 async function stopDaemon(folder: vscode.Uri, retry=true): Promise<void> {
 	output(`Stop daemon: ${folder.fsPath}`);
 
-	const result = await runDmypy(folder, ['stop']);
+	const result = await execDmypy({ folder, dmypyArgs: ['stop'] });
 	if (result.success) {
 		output(`Stopped daemon: ${folder.fsPath}`);
 	} else {
@@ -267,16 +276,59 @@ async function stopDaemon(folder: vscode.Uri, retry=true): Promise<void> {
 	}
 }
 
-async function runDmypy(folder: vscode.Uri, args: string[], warnIfFailed=false, successfulExitCodes?: number[], addPythonExecutableArgument=false, currentCheck?: number):
-	Promise<{ success: boolean, stdout: string | null }> {
+type DmypyMode = 'start' | 'restart' | 'status' | 'stop' | 'kill' | 'check' | 'run' | 'recheck' | 'suggest' | 'hang' | 'daemon' | 'help'
 
+interface DmypyExecConfig {
+	folder: vscode.Uri,
+	dmypyArgs: [DmypyMode, ...string[]],
+	warnIfFailed?: boolean,
+	successfulExitCodes?: number[],
+	addPythonExecutableArgument?: boolean,
+	currentCheck?: number,
+}
+
+interface DmypyRunConfig {
+	folder: vscode.Uri,
+	mypyArgs: string[],
+	currentCheck?: number,
+}
+
+async function runDmypy({
+	folder,
+	mypyArgs,
+	currentCheck,
+}: DmypyRunConfig): Promise<{ success: boolean, stdout: string | null }> {
+	let runArgs = ['--', ...mypyArgs];
+	const logfile = mkStoragePath(folder, folderHash => `dmypy-${folderHash}.log`);
+	if(logfile !== undefined) {
+		// --log-file <logfile> must come before '--' but after 'run'
+		runArgs = ['--log-file', logfile, ...runArgs];
+	}
+
+	return execDmypy({
+		folder,
+		dmypyArgs: ['run', ...runArgs],
+		warnIfFailed: true,
+		successfulExitCodes: [0, 1],
+		addPythonExecutableArgument: true,
+		currentCheck,
+	});
+}
+
+async function execDmypy({
+	folder,
+	dmypyArgs,
+	warnIfFailed = false,
+	successfulExitCodes,
+	addPythonExecutableArgument = false,
+	currentCheck
+}: DmypyExecConfig): Promise<{ success: boolean, stdout: string | null }> {
+
+	let args: string[] = dmypyArgs;
 	// Store the dmypy status file in the extension's workspace storage folder, instead of the
 	// default location which is .dmypy.json in the cwd.
-	if (_context?.storageUri !== undefined) {
-		fs.mkdirSync(_context.storageUri.fsPath, {recursive: true});
-		const folderHash = crypto.createHash('sha1').update(folder.toString()).digest('hex');
-		const statusFileName = `dmypy-${folderHash}.json`;
-		const statusFilePath = path.join(_context.storageUri.fsPath, statusFileName);
+	const statusFilePath = mkStoragePath(folder, folderHash => `dmypy-${folderHash}.json`);
+	if (statusFilePath !== undefined) {
 		args = ["--status-file", statusFilePath, ...args];
 	}
 	const activeInterpreter = await getActiveInterpreter(folder, currentCheck);
@@ -464,13 +516,17 @@ async function checkWorkspaceInternal(folder: vscode.Uri) {
 	output(`Check workspace: ${folder.fsPath}`, currentCheck);
 	const mypyConfig = vscode.workspace.getConfiguration("mypy", folder);
 	let targets = mypyConfig.get<string[]>("targets", []);
-	const args = ['run', '--', ...targets, '--show-column-numbers', '--no-error-summary', '--no-pretty', '--no-color-output']
+	const mypyArgs = [...targets, '--show-column-numbers', '--no-error-summary', '--no-pretty', '--no-color-output']
 	const configFile = mypyConfig.get<string>("configFile");
 	if (configFile) {
 		output(`Using config file: ${configFile}`, currentCheck);
-		args.push('--config-file', configFile);
+		mypyArgs.push('--config-file', configFile);
 	}
-	const result = await runDmypy(folder, args, true, [0, 1], true, currentCheck);
+	const result = await runDmypy({
+		folder,
+		mypyArgs,
+		currentCheck,
+	});
 
 	activeChecks--;
 	if (activeChecks == 0) {


### PR DESCRIPTION
Uses `${_context.storageUri.fsPath}/dmypy-${folderHash}.log` as a log file when running dmypy (produced by a new helper `mkStoragePath`).

`runDmypy` is renamed to `execDmypy` (for general `dmypy` invocations) and the new `runDmypy` specifically invokes the `dmypy run` sub-command.

Resolves the rest of #29 on my side.