### PR TITLE
Allow Mypy to be disabled for folders/projects in a monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
             "title": "Mypy",
             "type": "object",
             "properties": {
+                "mypy.enabled": {
+                    "type": "boolean",
+                    "default": "true",
+                    "scope": "resource",
+                    "description": "Enable or disable Mypy for this workspace/folder. Use this to disable checking in a monorepo."
+                },
                 "mypy.executable": {
                     "type": "string",
                     "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -593,6 +593,13 @@ async function checkWorkspaceInternal(folder: vscode.Uri) {
 
 	output(`Check workspace: ${folder.fsPath}`, currentCheck);
 	const mypyConfig = vscode.workspace.getConfiguration("mypy", folder);
+
+	if (!mypyConfig.enabled) {
+		output(`Mypy disabled for workspace: ${folder.fsPath}`, currentCheck);
+
+		return
+	}
+
 	let targets = mypyConfig.get<string[]>("targets", []);
 	const mypyArgs = [...targets, '--show-column-numbers', '--no-error-summary', '--no-pretty', '--no-color-output'];
 	const configFile = mypyConfig.get<string>("configFile");


### PR DESCRIPTION
Hi,

First of all, thanks for this extension! Please consider this to be a draft implementation to take care of https://github.com/matangover/mypy-vscode/issues/41. 

I'm not sure if this is the best place to add this check but I'm happy to move this check if another place is more appropriate. 

