### PR TITLE
feat: consolidate notes, add error code url

### DIFF
--- a/src/mypy.ts
+++ b/src/mypy.ts
@@ -1,1 +1,2 @@
-export const mypyOutputPattern = /^(?<file>[^\n]+?):((?<line>\d+):)?((?<column>\d+):)? (?<type>\w+): (?<message>.*)$/mg;
+export const mypyOutputPattern =
+	/^(?<location>(?<file>[^\n]+?):(?<line>\d+):(?<column>\d+):(?<endLine>\d+):(?<endColumn>\d+)): (?<type>\w+): (?<message>.*?)(?:  \[(?<code>[\w-]+)\])?$/;


### PR DESCRIPTION
## pr additions

- turn stack of notes into one diagnostic for ease of use/readability
- use `--show-error-end` flag to give better diagnostic ranges
- add error code support so users can easily see documentation about errors

## comparisions

|                                        |                                                              old                                                              |                                                              new                                                              |
| :------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------: |
|         notes/error code links         | ![old notes/error code links](https://github.com/matangover/mypy-vscode/assets/41439633/05039098-4103-4bc8-9b13-f04b3b032e00) | ![new notes/error code links](https://github.com/matangover/mypy-vscode/assets/41439633/4b7d4ec8-f0ad-49b7-8b6b-3b7b82376d91) |
| diagnostic range (missing return type) |    ![new diagnostic range](https://github.com/matangover/mypy-vscode/assets/41439633/ce186116-d655-42c6-90ac-8d3f8705e839)    |    ![old diagnostic range](https://github.com/matangover/mypy-vscode/assets/41439633/791d6502-7b58-4ad3-b712-845ea6b35dfc)    |
