### PR TITLE
change dmypy exec not found warning to simple output

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -367,10 +367,9 @@ async function getDmypyExecutable(folder: vscode.Uri, warnIfFailed: boolean, cur
 	if (isCommand) {
 		const executable = await lookpath(dmypyExecutable);
 		if (executable === undefined) {
-			warn(
+			output(
 				`The mypy daemon executable ('${dmypyExecutable}') was not found on your PATH. ` +
-				`Please install mypy or adjust the mypy.dmypyExecutable setting.`,
-				warnIfFailed, currentCheck
+				`Please install mypy or adjust the mypy.dmypyExecutable setting.`
 			)
 			return undefined;
 		}
@@ -378,10 +377,9 @@ async function getDmypyExecutable(folder: vscode.Uri, warnIfFailed: boolean, cur
 	} else {
 		dmypyExecutable = untildify(dmypyExecutable).replace('${workspaceFolder}', folder.fsPath)
 		if (!fs.existsSync(dmypyExecutable)) {
-			warn(
+			output(
 				`The mypy daemon executable ('${dmypyExecutable}') was not found. ` +
-				`Please install mypy or adjust the mypy.dmypyExecutable setting.`,
-				warnIfFailed, currentCheck
+				`Please install mypy or adjust the mypy.dmypyExecutable setting.`
 			)
 			return undefined;
 		}


### PR DESCRIPTION
I'm not sure if this breaks anything, but it should solve an annoying problem that I have: when in a VS Code workspace with multiple Python and non-Python project folders, I get multiple `Please install mypy or adjust the mypy.dmypyExecutable setting` notifications for non-Python folders. When opening a single folder, this is not a big deal, but getting warning notifications for every non-pythonic project in a big workspace seems like overkill to me. After this change, the line just gets written to output, and if I do need `mypy` for a folder and don't see its warnings in it, I can just go to the Output tab and check there.