### PR TITLE
feat: custom roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To configure the mypy-vscode extension, use the following VS Code settings:
 
 * `mypy.targets`: specify a list of target files or folders for mypy to analyze. By default the entire workspace folder is checked. You may prefer to use the `files` option in `mypy.ini` to specify which files mypy should analyze. In that case, you should set `mypy.targets` to an empty array (`[]`).
 
+* `mypy.roots`: Specify a list of root folders. Each root is checked by its own mypy daemon. If not set, the workspace folders are used. This is useful for monorepos when you are not using a normal multi-root workspace. This setting is ignored in multi-root workspaces.
+
 * `mypy.dmypyExecutable`: Path to `dmypy` (the mypy daemon). Either a full path or just a name (which must exist in your PATH). You can use substitutions: `${workspaceFolder}` and `~` (home directory).
 
 * `mypy.runUsingActiveInterpreter`: Use the active Python interpreter (selected in the Python extension) to run dmypy itself, instead of the `mypy.dmypyExecutable` setting. Note: your code is always checked against the active interpreter – this setting only controls the interpreter used to run dmypy itself.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,16 @@
                     "uniqueItems": true,
                     "description": "List of paths to analyze, relative to the workspace folder. By default, check the entire workspace folder."
                 },
+                "mypy.roots": {
+                    "type": "array",
+                    "default": [],
+                    "scope": "resource",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "List of paths to consider as roots, relative to the workspace folder. Each root is checked by its own mypy daemon. If not set, use the workspace folders. This is useful for monorepos when not in a normal multi-root workspace. This setting is ignored in multi-root workspaces."
+                },
                 "mypy.checkNotebooks": {
                     "type": "boolean",
                     "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -386,15 +386,16 @@ async function killDaemon(folder: vscode.Uri, currentCheck: number | undefined, 
 }
 
 async function recheckWorkspace() {
-	output("Rechecking workspace");
 	// if the user has chosen custom roots with `mypy.roots`, and there is only one workspace folder, check those roots.
 	const mypyConfig = vscode.workspace.getConfiguration('mypy');
 	const roots = mypyConfig.get<string[]>("roots", []);
 	if (roots.length > 0 && vscode.workspace.workspaceFolders?.length === 1) {
+		output("Rechecking custom roots");
 		const base = vscode.workspace.workspaceFolders[0];
 		const folders = roots.map(root => vscode.Uri.file(path.join(base.uri.fsPath, root)));
 		await forEachFolder(folders, folder => checkWorkspace(folder));
 	} else {
+		output("Rechecking workspace");
 		await forEachFolder(vscode.workspace.workspaceFolders, folder => checkWorkspace(folder.uri));
 	}
 	output("Recheck complete");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,7 +298,7 @@ async function runDmypy(
 			if (ex.stderr) {
 				output(`stderr:\n${ex.stderr}`, currentCheck);
 				if (ex.stderr.indexOf('Daemon crashed!') != -1) {
-					error = 'the mypy daemon crashed. This is probably a bug in mypy itself, ' + 
+					error = 'the mypy daemon crashed. This is probably a bug in mypy itself, ' +
 					'see Output panel for details. The daemon will be restarted automatically.'
 					showDetailsButton = true;
 				} else if (ex.stderr.indexOf('There are no .py[i] files in directory') != -1) {
@@ -330,7 +330,7 @@ async function runDmypy(
 						output("Retrying command", currentCheck);
 						return await runDmypy(folder, dmypyCommand, mypyArgs, warnIfFailed, successfulExitCodes, addPythonExecutableArgument, currentCheck, false);
 					} else {
-						error = 'the mypy daemon is stuck. An attempt to kill it and retry failed. ' + 
+						error = 'the mypy daemon is stuck. An attempt to kill it and retry failed. ' +
 						'This is probably a bug in mypy itself, see Output panel for details.';
 						showDetailsButton = true;
 					}
@@ -387,7 +387,16 @@ async function killDaemon(folder: vscode.Uri, currentCheck: number | undefined, 
 
 async function recheckWorkspace() {
 	output("Rechecking workspace");
-	await forEachFolder(vscode.workspace.workspaceFolders, folder => checkWorkspace(folder.uri));
+	// if the user has chosen custom roots with `mypy.roots`, and there is only one workspace folder, check those roots.
+	const mypyConfig = vscode.workspace.getConfiguration('mypy');
+	const roots = mypyConfig.get<string[]>("roots", []);
+	if (roots.length > 0 && vscode.workspace.workspaceFolders?.length === 1) {
+		const base = vscode.workspace.workspaceFolders[0];
+		const folders = roots.map(root => vscode.Uri.file(path.join(base.uri.fsPath, root)));
+		await forEachFolder(folders, folder => checkWorkspace(folder));
+	} else {
+		await forEachFolder(vscode.workspace.workspaceFolders, folder => checkWorkspace(folder.uri));
+	}
 	output("Recheck complete");
 }
 
@@ -765,7 +774,7 @@ function parseMypyOutput(stdout: string, folder: vscode.Uri) {
 			}
 		}
 	});
-	
+
 	let fileDiagnostics = new Map<vscode.Uri, vscode.Diagnostic[]>();
 	for (const line of outputLines) {
 		const diagnostic = createDiagnostic(line);
@@ -795,7 +804,7 @@ function getLinkUrl(line: MypyOutputLine) {
 
 function getFileUri(filePath: string, folder: vscode.Uri) {
 	// By default mypy outputs paths relative to the checked folder. If the user specifies
-	// `show_absolute_path = True` in the config file, mypy outputs absolute paths.	
+	// `show_absolute_path = True` in the config file, mypy outputs absolute paths.
 	if (!path.isAbsolute(filePath)) {
 		filePath = path.join(folder.fsPath, filePath);
 	}
@@ -823,7 +832,7 @@ function createDiagnostic(line: MypyOutputLine) {
 		}
 	}
 	const range = new vscode.Range(lineNo, column, endLineNo, endColumn);
-	
+
 	const diagnostic = new vscode.Diagnostic(
 		range,
 		line.message,
@@ -979,7 +988,7 @@ async function filesChanged(files: readonly vscode.Uri[], created = false) {
 		const folder = vscode.workspace.getWorkspaceFolder(file);
 		if (folder === undefined)
 			continue;
-		
+
 		const path = file.fsPath;
 		if (path.endsWith(".py") || path.endsWith(".pyi") || path.endsWith(".ipynb")) {
 			folders.add(folder.uri);


### PR DESCRIPTION
i'm working with a monorepo, and i can't use a multi-root workspace as it causes vscode to slow to a crawl for some reason (can be 30+ seconds delay on completions, linters, et cetera.) i suspect it may be due to the remote devcontainer workspaces we use. that issue aside, i personally find multi-root workspaces to be a little unwieldy and difficult to manage, getting worse as more roots are added.

i saw #82 and thought that might work for my needs, so i had a go at a prototype implementation. right now it only exists as part of the "recheck" command to make it easier to test, and i wasn't too confident about how to properly integrate it with the extension to start automatically and properly handle changes to the workspace, settings, et cetera.

by way of a demo, i set up a structure to mimic the monorepo i use with some intentional type errors in each of the packages:

```
.
├── README.md
└── src
    ├── package1
    │   ├── package1
    │   │   └── __init__.py
    │   ├── pyproject.toml
    │   ├── README.md
    │   └── tests
    │       └── __init__.py
    ├── package2
    │   ├── package2
    │   │   └── __init__.py
    │   ├── pyproject.toml
    │   ├── README.md
    │   └── tests
    │       └── __init__.py
    └── package3
        ├── package3
        │   └── __init__.py
        ├── pyproject.toml
        ├── README.md
        └── tests
            └── __init__.py
```

i configure the extension like so:

```json
{
    "mypy.roots": [
        "src/package1",
        "src/package2",
        "src/package3",
    ]
}
```

starting the extension in this workspace normally raises the following issue:

```
[1] Mypy output:
Daemon started
src/package2/tests/__init__.py: error: Duplicate module named "tests" (also at "./src/package1/tests/__init__.py")
src/package2/tests/__init__.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
src/package2/tests/__init__.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH
```

i then run `Mypy: Recheck Workspace` to trigger the code i added, and i see the following:

```
[4] Mypy output:
Daemon started
package3/__init__.py:6:4:6:6: error: Argument 1 to "p3" has incompatible type "int"; expected "str"  [arg-type]
tests/__init__.py:4:4:4:6: error: Argument 1 to "p3" has incompatible type "int"; expected "str"  [arg-type]

[2] Mypy output:
Daemon started
package1/__init__.py:6:4:6:6: error: Argument 1 to "p1" has incompatible type "int"; expected "str"  [arg-type]
tests/__init__.py:4:4:4:6: error: Argument 1 to "p1" has incompatible type "int"; expected "str"  [arg-type]

[3] Mypy output:
Daemon started
package2/__init__.py:6:4:6:6: error: Argument 1 to "p2" has incompatible type "int"; expected "str"  [arg-type]
tests/__init__.py:4:4:4:6: error: Argument 1 to "p2" has incompatible type "int"; expected "str"  [arg-type]
```

![image](https://github.com/user-attachments/assets/669fc62c-09fd-429a-91b6-e1e5c3f7ea88)

at its most basic level, this is working the way i want it to.

if you like the way this is going, i would really appreciate any assistance you can offer towards getting this worked into a proper functioning feature! i am very inexperienced in both typescript and vscode extension development, so i could use all the help i can get.

p.s. sorry for the excess changes, vscode was very set on reformatting everything constantly. if it's annoying i'll edit the commits to remove any non-functional changes.

thanks!