### PR TITLE
Support configuring an envFile for the mypy environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "async-lock": "^1.2.8",
                 "child-process-promise": "^2.2.1",
+                "envfile": "^7.1.0",
                 "lookpath": "^1.2.0",
                 "promise.allsettled": "^1.0.4",
                 "shlex": "^2.0.2",
@@ -415,6 +416,20 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/envfile": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/envfile/-/envfile-7.1.0.tgz",
+            "integrity": "sha512-dyH4QnnZsArCLhPASr29eqBWDvKpq0GggQFTmysTT/S9TTmt1JrEKNvTBc09Cd7ujVZQful2HBGRMe2agu7Krg==",
+            "bin": {
+                "envfile": "bin.cjs"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
         },
         "node_modules/es-abstract": {
             "version": "1.18.0-next.2",
@@ -1783,6 +1798,11 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "envfile": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/envfile/-/envfile-7.1.0.tgz",
+            "integrity": "sha512-dyH4QnnZsArCLhPASr29eqBWDvKpq0GggQFTmysTT/S9TTmt1JrEKNvTBc09Cd7ujVZQful2HBGRMe2agu7Krg=="
         },
         "es-abstract": {
             "version": "1.18.0-next.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
                     "scope": "resource",
                     "markdownDescription": "Mypy config file, relative to the workspace folder. If empty, search in the default locations. See https://mypy.readthedocs.io/en/latest/config_file.html."
                 },
+                "mypy.envFile": {
+                    "type": "string",
+                    "default": "",
+                    "scope": "resource",
+                    "markdownDescription": "Env file, relative to the workspace folder. Useful for setting environment variables for the mypy process."
+                },
                 "mypy.targets": {
                     "type": "array",
                     "default": [
@@ -144,6 +150,7 @@
     "dependencies": {
         "async-lock": "^1.2.8",
         "child-process-promise": "^2.2.1",
+        "envfile": "^7.1.0",
         "lookpath": "^1.2.0",
         "promise.allsettled": "^1.0.4",
         "shlex": "^2.0.2",


### PR DESCRIPTION
Fixes #25, see https://github.com/matangover/mypy-vscode/issues/25#issuecomment-2406633965 for an example to reproduce the issue of needing environment variables. This is most commonly necessary when using the `django-stubs` plugin because a full fledged django environment is necessary to execute type checking. Warning: I don't really write typescript, I just sort of threw this together and it appears to work for me.