### PR TITLE
Add config option for working directory to run dmypy in

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To configure the mypy-vscode extension, use the following VS Code settings:
 
 * `mypy.statusFile`: Path to status file used by dmypy, relative to the workspace folder. By default, the status file is stored in a temporary location. Specify a name such as `.dmypy.json` to use a fixed location for the status file, so that you can reuse the daemon outside of VS Code. Reusing the daemon might cause issues, but can be useful for large codebases.
 
+* `mypy.currentWorkingDirectory`: Current working directory to invoke mypy from, relative to the workspace folder. Defaults to the workspace folder.
+
 ## Experimental: Type checking in notebooks
 
 This extension can also run mypy on Python code cells in Jupyter notebooks. To enable this feature, set `mypy.checkNotebooks` to `true`. Notebooks are type checked when they're opened or saved.

--- a/package.json
+++ b/package.json
@@ -119,6 +119,12 @@
                     "default": "",
                     "scope": "resource",
                     "markdownDescription": "Path to status file used by dmypy, relative to the workspace folder. By default, the status file is stored in a temporary location. Specify a name such as `.dmypy.json` to use a fixed location for the status file, so that you can reuse the daemon outside of VS Code. Reusing the daemon might cause issues, but can be useful for large codebases."
+                },
+                "mypy.currentWorkingDirectory": {
+                    "type": "string",
+                    "default": ".",
+                    "scope": "resource",
+                    "markdownDescription": "Current working directory to invoke mypy from, relative to the workspace folder. Defaults to the workspace folder."
                 }
             }
         },


### PR DESCRIPTION
# Description

This adds a config option to allow customizing the current working directory that mypy is executed from. 

This is a useful option for repositories where mypy needs to be invoked from a subdirectory, for values in the mypy config that are relative to the _current working directory_ rather than the config path.

To preserve backwards compatibility with other config settings, `targets` and `configPath` are interpreted relative to the workspace folder and turned absolute when generating the mypy command arguments.

Resolves https://github.com/matangover/mypy-vscode/issues/89

# Test Plan

To package and install extension locally:
```
npm install -g @vscode/vsce
vsce package
code --install-extension mypy-0.4.2.vsix
```

Using a fork of the [repro repository](https://github.com/utybo/mypy-issue-89-repro) with a [patch applied](https://github.com/rodmk/mypy-issue-89-repro/pull/1/files) to set the cwd config option, open up VSCode and verify that only one issue is reported this time.

<img width="1787" alt="Screenshot 2025-05-22 at 10 15 52 AM" src="https://github.com/user-attachments/assets/689912f5-17c7-4f38-8efc-5d363ff68f13" />

This matches the results obtained when running mypy directly under the `my-python-project` subdirectory.

```
(venv) ~/src/mypy-issue-89-repro/my-python-project rodmk/mypy_cwd_config
$ mypy .
my_python_project/reportme.py:2: error: Incompatible return value type (got "int", expected "str")  [return-value]
Found 1 error in 1 file (checked 3 source files)
``` 

Verify that without the cwd option set, mypy still runs as usual and reports two errors, as it did prior to this PR.

<img width="1787" alt="Screenshot 2025-05-22 at 10 17 38 AM" src="https://github.com/user-attachments/assets/144a4383-9b70-4146-9317-a0f5a35a7d65" />